### PR TITLE
Make sure to restore excludedFilterFields at initialization of metadata

### DIFF
--- a/lib/filters/decorators/field.decorator.ts
+++ b/lib/filters/decorators/field.decorator.ts
@@ -22,6 +22,7 @@ export class GraphqlFilterTypeDecoratorMetadata {
 
     if (meta) {
       this.fields = meta.fields;
+      this.excludedFilterFields = meta.excludedFilterFields;
     }
   }
   

--- a/lib/sorting/decorators/field.decorator.ts
+++ b/lib/sorting/decorators/field.decorator.ts
@@ -29,6 +29,7 @@ export class GraphqlSortingTypeDecoratorMetadata {
 
     if (meta) {
       this.fields = meta.fields;
+      this.excludedFilterFields = meta.excludedFilterFields;
     }
   }
   


### PR DESCRIPTION
The exclude on field decorator is currently not working because it is not properly restored from metadata at initialization of GraphqlFilterTypeDecoratorMetadata.

This pull request fixes that issue